### PR TITLE
Fix error in the poliyfills

### DIFF
--- a/example/poliyfills.ts
+++ b/example/poliyfills.ts
@@ -2,4 +2,4 @@ import ws from 'ws'
 
 // polyfill fetch & websocket
 const globalAny = global as any
-globalAny.WebSocket = ws
+globalAny.WebSocket = ws.WebSocket;


### PR DESCRIPTION
import ws from 'ws';

return

{
"Receiver": [Function: Receiver],
    "Sender": [Function: Sender],
    "WebSocket": [Function: BunWebSocket],
    "WebSocketServer": [Function: WebSocketServer],
    "createWebSocketStream": [Function],
    "default": [Function: BunWebSocket]
}

the @trpc/client is not compatible

69 |         }
70 |         request(req.op, req.callbacks);
71 |     }
72 |     function createWS() {
73 |         const urlString = typeof url === 'function' ? url() : url;
74 |         const conn = new WebSocketImpl(urlString);
                         ^
TypeError: Module is not a constructor (evaluating 'new WebSocketImpl(urlString)')
      at createWS (/Users/bob/Sites/test-elysiajs/node_modules/@trpc/client/dist/links/wsLink.mjs:74:21)
      at createWSClient (/Users/bob/Sites/test-elysiajs/node_modules/@trpc/client/dist/links/wsLink.mjs:18:27)
      at /Users/bob/Sites/test-elysiajs/client.ts:20:16