### PR TITLE
Only handle valid incoming messages and properly get the input data for a subscription route

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,10 @@ export const trpc =
                     let observer: Unsubscribable | undefined
 
                     for (const incoming of messages) {
+                        if(!incoming.method || !incoming.params) {
+                          continue
+                        }
+
                         if (incoming.method === 'subscription.stop') {
                             observer?.unsubscribe()
                             observers.delete(ws.data.id.toString())

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export const trpc =
                         const result = await callProcedure({
                             procedures: router._def.procedures,
                             path: incoming.params.path,
-                            rawInput: incoming.params.input,
+                            rawInput: incoming.params.input?.json,
                             type: incoming.method,
                             ctx: {}
                         })

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,9 @@ export interface TRPCClientIncomingRequest {
     method: 'query' | 'mutation' | 'subscription' | 'subscription.stop'
     params: {
         path: string
-        input?: unknown
+        input?: {
+            json?: unknown
+        }
     }
 }
 


### PR DESCRIPTION
I got errors saying that "incoming.params.path" is undefined when using trpc subscriptions. Upon investigation, I noticed that the first "incoming" value is actually an empty array and not the object that is expected. I added a simple condition to filter out these invalid values.

My input value to the subscription route was also not coming though. When I logged the incoming object, I noticed that the input values are not in "incoming.params.input" directly, but there is an additional "json" level where the input values can be found. I added "json" to the object path for the input. Not sure if it's correct but it works.