### PR TITLE
Add return type from schema to the compile()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export function compile<T extends TSchema>(schema: T) {
     if (!check) throw new Error('Invalid schema')
 
     return (value: unknown) => {
-        if (check.Check(value)) return value
+        if (check.Check(value)) return value as (typeof schema)["static"]
 
         const { path, message } = [...check.Errors(value)][0]
 
@@ -78,6 +78,10 @@ export const trpc =
                     let observer: Unsubscribable | undefined
 
                     for (const incoming of messages) {
+                        if(!incoming.method || !incoming.params) {
+                          continue
+                        }
+
                         if (incoming.method === 'subscription.stop') {
                             observer?.unsubscribe()
                             observers.delete(ws.data.id.toString())
@@ -96,7 +100,7 @@ export const trpc =
                         const result = await callProcedure({
                             procedures: router._def.procedures,
                             path: incoming.params.path,
-                            rawInput: incoming.params.input,
+                            rawInput: incoming.params.input?.json,
                             type: incoming.method,
                             ctx: {}
                         })

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,9 @@ export interface TRPCClientIncomingRequest {
     method: 'query' | 'mutation' | 'subscription' | 'subscription.stop'
     params: {
         path: string
-        input?: unknown
+        input?: {
+            json?: unknown
+        }
     }
 }
 


### PR DESCRIPTION
Right now the result of the compile() is (unknown) => unknown, so it is not typesafe. Bumped into to this when trying to use Treaty for input validation in trpc.